### PR TITLE
Pull Request: add() now returns the model instead of undefined.

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -71,7 +71,7 @@
     add: function(attrStr, value, opts){
       var current = this.get(attrStr);
       if (!_.isArray(current)) throw new Error('current value is not an array');
-      this.set(attrStr + '[' + current.length + ']', value, opts);
+      return this.set(attrStr + '[' + current.length + ']', value, opts);
     },
 
     remove: function(attrStr, opts){

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -493,6 +493,22 @@ $(document).ready(function() {
     ok(callbackFired, "callback wasn't fired");
   });
 
+  test("#add() should return the model to mimic set() functionality", function() {
+    var callbackFired = false;
+    var model;
+
+    model = doc.set('addresses.0.city', 'Boston');
+
+    equal(model, doc);
+
+    model = doc.add('addresses', {
+      city: 'Lincoln',
+      state: 'NE'
+    });
+
+    equal(model, doc);
+  });
+
 
   // ----- REMOVE --------
 
@@ -532,6 +548,19 @@ $(document).ready(function() {
     }
 
     ok(errorRaised, "error wasn't raised");
+  });
+
+  test("#remove() should return the model to mimic set() functionality", function() {
+    var callbackFired = false;
+    var model;
+
+    model = doc.set('addresses.0.city', 'Boston');
+
+    equal(model, doc);
+
+    model = doc.remove('addresses[0]');
+
+    equal(model, doc);
   });
 
 });


### PR DESCRIPTION
This wasn't a big deal, but an annoying inconsistency with an easy fix.  The core Backbone `set()` function returns the model (or `false` if there is validation but it fails).  However, the `add()` function for Backbone.NestedModel was returning `undefined` because it was missing an explicit return statement.

Added a test and the fix.  Also added a test in to confirm that the `remove()` function returns the model, which it did already without any changes by me.
