### PR TITLE
Fixes #21

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -65,9 +65,7 @@
     },
 
     unset: function(attrStr, opts){
-      opts = _.extend({}, opts, {unset: true});
-      this.set(attrStr, null, opts);
-
+      this.set(attrStr, undefined, opts);
       return this;
     },
 
@@ -158,7 +156,7 @@
           }
           
           // Trigger Remove Event if array being set to null
-          if (value === null){
+          if (_.isNull(value) || _.isUndefined(value)){
             var parentPath = Backbone.NestedModel.createAttrStr(_.initial(attrPath));
             model._delayedTrigger('remove:' + parentPath, model, val[attr]);
           }

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -623,6 +623,14 @@ $(document).ready(function() {
     ok(_.isUndefined(doc.get('name.first')));
   });
 
+  test("#unset() nested attribute does not affect other attributes", function() {
+    equal(doc.get('gender'), 'M');
+
+    doc.unset('name.first');
+
+    equal(doc.get('gender'), 'M', 'Gender field should not be affected by unsetting first name');
+  });
+
 
   // ----- ADD --------
 


### PR DESCRIPTION
I'm not 100% sure whether a good reason might exist to call the core Backbone.Model `opts.unset` attribute.  Assuming there isn't, this commit fixes #21 by calling `this.set()` with `undefined` and removing that opts override.  Added a test as well to show the functionality that wasn't working.
