### PR TITLE
Added tests for options being passed to trigger()

### DIFF
--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -641,6 +641,33 @@ $(document).ready(function() {
     sinon.assert.calledOnce(removeNameMiddleFullAlternates);
   });
 
+  test("#set() options passed through to #trigger()", function() {
+    var callback = function(model, newVal, options){
+      ok(options)
+      deepEqual(options.meta, {
+        user: 'Matt',
+        time: '14:58'
+      });
+    };
+
+    doc.bind('change:gender', callback);
+
+    doc.set('gender', 'F', {meta: {user: 'Matt', time: '14:58'}});
+  });
+
+  test("#set() options passed through to #trigger() when setting a nested attribute", function() {
+    var callback = function(model, newVal, options){
+      ok(options);
+      deepEqual(options.meta, {
+        user: 'Scott',
+        time: '15:04'
+      });
+    };
+
+    doc.bind('change:name.first', callback);
+
+    doc.set('name.first', 'Dan', {meta: {user: 'Scott', time: '15:04'}});
+  });
 
   // ----- CHANGED_ATTRIBUTES --------
 


### PR DESCRIPTION
When setting a root level attribute, set() will pass the options it was called with to trigger(). When setting a nested attribute this does not happen.
