### PR TITLE
Check for circular references in checkChanges

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -227,7 +227,15 @@
 
           // Trigger Change Event if new values are being set
           if (!opts.silent && _.isObject(newValue) && isNewValue){
+            var visited = [];
             var checkChanges = function(obj, prefix) {
+              // Don't choke on circular references
+              if(visited.indexOf(obj) > -1) {
+                return;
+              } else {
+                visited.push(obj);
+              }
+
               var nestedAttr, nestedVal;
               for (var a in obj){
                 if (obj.hasOwnProperty(a)) {

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -369,6 +369,22 @@ $(document).ready(function() {
     sinon.assert.notCalled(changeGender);
   });
 
+  test("change events on nested Backbone collection", function() {
+    // Set up a circular reference - models inside a collection have a
+    // `collection` property and collections have '0' property pointing
+    // to the collection/model, respectively
+    var children = new Backbone.Collection();
+    var child = new Backbone.NestedModel();
+    children.add(child);
+
+    var change = sinon.spy();
+
+    doc.bind('change:children', change);
+    doc.set({'children': children});
+
+    sinon.assert.called(change);
+  });
+
   test("change event doesn't fire on silent", function() {
     var change = sinon.spy();
     var changeName = sinon.spy();


### PR DESCRIPTION
Backbone collections set up a circular reference: collection[i] is a reference
to a model, and model.collection is a reference back to the collection.
checkChanges needs to not run in circles when encountering this.

Fixes #79
