### PR TITLE
Add options argument to change:nested.property event's handle function

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -113,7 +113,7 @@
 
           val = obj[attr];
           if (_.isObject(val)) { // clear child attrs
-            setChanged(val, changedPath);
+            setChanged(val, changedPath, options);
           }
           if (!options.silent) model._delayedChange(changedPath, null, options);
           changed[changedPath] = null;

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -512,6 +512,17 @@ $(document).ready(function() {
     doc.set({'name.first': 'Bob'});
   });
 
+  test("attribute change event receives options witch set by model.set method", function() {
+    doc.bind('change:name', function(model, newVal, options){
+        strictEqual(options.someOption, true);
+    });
+    doc.bind('change:name.first', function(model, newVal, options){
+        strictEqual(options.someOption, true);
+    });
+
+    doc.set({'name.first': 'Bob'}, {someOption: true});
+  });
+
   test("change event on deeply nested attribute", function() {
     var change = sinon.spy();
     var changeName = sinon.spy();
@@ -685,7 +696,6 @@ $(document).ready(function() {
     sinon.assert.calledOnce(changeNameMiddleFullAlternates);
     sinon.assert.calledOnce(removeNameMiddleFullAlternates);
   });
-
 
   // ----- CHANGED_ATTRIBUTES --------
 


### PR DESCRIPTION
This commit add `options` arg witch could be set by model.set method to `change:nested.property` event's handle function.

Example:

```
view.listenTo(model, 'change:name.first', function ( model, newVal, options){
    if( options.silentToView ){
        return;
    }
    // do normal process...
});

model.set('name.first', 'LiZn', {silentToView: true});
```
