### PR TITLE
Add support for CommonJS, AMD, and global namespace usage methods.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,8 +24,10 @@ module.exports = function(grunt) {
     qunit: {
       index: ['test/index.html']
     },
-    tape: {
-        files: ['test/tape-*.js']
+    mochaTest: {
+        test: {
+            src: ['test/mocha-*.js']
+        }
     },
     watch: {
       files: ['<config:lint.files>', 'test/**'],
@@ -35,8 +37,8 @@ module.exports = function(grunt) {
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-qunit');
-  grunt.loadNpmTasks('grunt-tape');
+  grunt.loadNpmTasks('grunt-mocha-test');
 
   // Default task.
-  grunt.registerTask('default', ['jshint', 'qunit', 'tape']);
+  grunt.registerTask('default', ['jshint', 'qunit', 'mochaTest']);
 };

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "grunt": "~0.4.1",
     "grunt-contrib-qunit": "~0.2.2",
     "grunt-contrib-jshint": "~0.6.4",
-    "grunt-tape": "0.0.2",
+    "grunt-mocha-test": "~0.8.2",
     "grunt-contrib-watch": "~0.5.3",
     "jslitmus": "~0.1.0",
-    "tape": "~2.3.2"
+    "mocha": "~1.17.1"
   },
   "peerDependencies": {
     "grunt-cli": "*",

--- a/test/mocha-require.js
+++ b/test/mocha-require.js
@@ -1,0 +1,11 @@
+/*global describe, it*/
+var assert = require('assert');
+
+var Backbone = require('backbone');
+require('../backbone-nested');
+
+describe("CommonJS support", function() {
+    it('should attach to Backbone when require backbone-nested', function() {
+        assert.ok(Backbone.NestedModel);
+    });
+});

--- a/test/tape-require.js
+++ b/test/tape-require.js
@@ -1,8 +1,0 @@
-var test = require('tape');
-var Backbone = require('backbone');
-require('../backbone-nested');
-
-test('require backbone-nested should attach to Backbone', function(t) {
-    t.ok(Backbone.NestedModel);
-    t.end();
-});


### PR DESCRIPTION
I want to use modules like [browserify](http://browserify.org/) with backbone-nested, but found I could not in its current state. This adjustment adds CommonJS, AMD, and keeps the global `window` namespace support.

Some things I'm curious about:
- Tests for this are possible, but I'm only familiar with mocha. The tests you have within QUnit seem to continue passing, though.
- Wonder if we can remove the jQuery dependency by finding a different method to `deepClone`?

I am fairly new to using CommonJS modules in the browser but the pattern I used below is the same one used by other backbone modules like [backbone.epoxy](https://github.com/gmac/backbone.epoxy/blob/master/backbone.epoxy.js)

Thanks for your time, and I hope this helps!
