### PR TITLE
Look ahead one step when building nested structures (#78)

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -250,7 +250,6 @@
         var attr = _.last(path);
         var attrStr = Backbone.NestedModel.createAttrStr(path);
 
-
         // See if this is a new value being set
         var isNewValue = !_.isEqual(val[attr], newValue);
 

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -326,7 +326,7 @@ $(document).ready(function() {
     var provider = new Klass({
       "fields.0.key": 'LOGIN2'
     });
-    equal(provider.get('fields.0..key'), 'LOGIN2');
+    equal(provider.get('fields.0.key'), 'LOGIN2');
 
     deepEqual(provider.toJSON(), {
       "fields": [{
@@ -334,7 +334,6 @@ $(document).ready(function() {
       }]
     });
   });
-
 
 
   // ----- CHANGE EVENTS --------


### PR DESCRIPTION
To determine whether a newly created nest-level should be an object or
an array, we need to look at the next value in the path.
Please run the tests without the patch in backbone-nested to see the bug
in action. Thanks

Closes #78
