### PR TITLE
restrict NPM installs based on installed node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 # based off http://ariya.ofilabs.com/2012/03/phantomjs-and-travis-ci.html
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.11"
 before_install:
-  - npm install grunt-cli -g
+  - npm install grunt-cli bower -g


### PR DESCRIPTION
attempt to fix build on Node 0.8, where NPM was attempting to install
Bower 1.3.8, which is incompatible

https://github.com/npm/npm/issues/3662#issuecomment-21142618
