### PR TITLE
remove bower dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,7 @@
     "grunt-mocha-test": "~0.8.2",
     "grunt-contrib-watch": "~0.5.3",
     "jslitmus": "~0.1.0",
-    "mocha": "~1.17.1"
-  },
-  "peerDependencies": {
+    "mocha": "~1.17.1",
     "grunt-cli": "*",
     "bower": "*"
   },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.0.1",
   "description": "A plugin to make Backbone.js keep track of nested attributes.",
   "scripts": {
-    "install": "bower install",
     "test": "grunt"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, 'npm install backbone-nested' requires bower.  It shouldn't.