### PR TITLE
Apply custom opts, related to a specific field

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -69,10 +69,10 @@
         var attrs = key;
         for (var _attrStr in attrs) {
           if (attrs.hasOwnProperty(_attrStr)) {
-+            // Apply custom opts, related to a specific field
-+           if (opts.byField && opts.byField[_attrStr]) {
-+             opts = _.extend(opts, opts.byField[_attrStr]);
-+           }
+            // Apply custom opts, related to a specific field
+            if (opts.byField && opts.byField[_attrStr]) {
+              opts = _.extend(opts, opts.byField[_attrStr]);
+            }
             
             this._setAttr(newAttrs,
                           Backbone.NestedModel.attrPath(_attrStr),


### PR DESCRIPTION
Make possible to pass custom options per a specific field. Usage example:
 `document.fetch({byField: { 'custom_obj_field': { silent: true } } })`

Might be useful for huge object fields, on which triggering the `change` event is really painful.
