### PR TITLE
Fix previous

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -27,18 +27,11 @@
   Backbone.NestedModel = Backbone.Model.extend({
 
     get: function(attrStrOrPath){
-      var attrPath = Backbone.NestedModel.attrPath(attrStrOrPath),
-        result;
+      return Backbone.NestedModel.walkThenGet(this.attributes, attrStrOrPath);
+    },
 
-      Backbone.NestedModel.walkPath(this.attributes, attrPath, function(val, path){
-        var attr = _.last(path);
-        if (path.length === attrPath.length){
-          // attribute found
-          result = val[attr];
-        }
-      });
-
-      return result;
+    previous: function(attrStrOrPath){
+      return Backbone.NestedModel.walkThenGet(this._previousAttributes, attrStrOrPath);
     },
 
     has: function(attr){
@@ -366,6 +359,21 @@
         val = val[childAttr];
         if (!val) break; // at the leaf
       }
+    },
+
+    walkThenGet: function(attributes, attrStrOrPath){
+      var attrPath = Backbone.NestedModel.attrPath(attrStrOrPath),
+        result;
+
+      Backbone.NestedModel.walkPath(attributes, attrPath, function(val, path){
+        var attr = _.last(path);
+        if (path.length === attrPath.length){
+          // attribute found
+          result = val[attr];
+        }
+      });
+
+      return result;
     }
 
   });

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -121,6 +121,32 @@ $(document).ready(function() {
   });
 
 
+  // ----- PREVIOUS --------
+
+  test("$previous() 1-1 undefined previous at init", function() {
+    equal(doc.previous("gender"), undefined);
+    equal(doc.previous("name"), undefined);
+    equal(doc.previous("name.first"), undefined);
+    equal(doc.previous("unknown"), undefined);
+    equal(doc.previous("unknown2.field"), undefined);
+  });
+
+  test("$previous() 1-1 previous returning last value", function() {
+    doc.set("gender", 'F');
+    equal(doc.previous("gender"), 'M');
+
+    doc.set("name.first", "blah");
+    equal(doc.previous("name.first"), 'Aidan');
+
+    doc.set("unknown", "blah");
+    equal(doc.previous("unknown"), undefined);
+
+    doc.set("unknown2.field", "blah");
+    equal(doc.previous("unknown2.field"), undefined);
+    doc.set("unknown2.field", "bleh");
+    equal(doc.previous("unknown2.field"), "blah");
+  });
+
   // ----- HAS --------
 
   test("#get() 1-1", function() {


### PR DESCRIPTION
`previous()` call is not working for nested attributes

Making it work with this PR.

PS: Not sure about the naming of `walkThenGet ` utility method introduced .. don't hesitate to provide me any feedback I'll change it accordingly.