### PR TITLE
install npm modules in `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "2.0.3",
   "description": "A plugin to make Backbone.js keep track of nested attributes.",
   "scripts": {
-    "test": "bower install; grunt"
+    "pretest": "npm install && bower install",
+    "test": "grunt"
   },
   "dependencies": {
     "jquery": ">=1.8.3",


### PR DESCRIPTION
I figured we might as well run `npm install`, which seems to be quick when everything is cached and installed already, along with `bower install` (which is not so quick).