### PR TITLE
issue #68 fix - changed `nestedChanges` and `_delayedTriggers` scope, added tests accordingly

### DIFF
--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -1134,7 +1134,7 @@ $(document).ready(function() {
       // trigger a set on modelB when modelA is changed to create the issue of singleton _delayedTriggers 
       // the buggy behavior cause modelB to trigger modelA _delayedTriggers
       modelA.on("change:name", function(){
-          modelB.set("and.now.for.something.completly", "different");
+          modelB.set("and.now.for.something.completely", "different");
       });
       // assert true (expected behavior)
       modelA.on("change:name.first", function(){

--- a/test/nested-model.js
+++ b/test/nested-model.js
@@ -1116,5 +1116,35 @@ $(document).ready(function() {
 
     equal(model, doc);
   });
+  test("issue #68 - _delayedTriggers is a singleton", function() {
+      var modelA = new Klass({ 
+        modelName: "modelA",
+        name: {
+            first: "andrew",
+            last: "goldis"
+        }
+      });
+      var modelB = new Klass({ 
+        modelName: "modelB",
+        name: {
+            first: "eyal",
+            last: "keren"
+        }
+      });
+      // trigger a set on modelB when modelA is changed to create the issue of singleton _delayedTriggers 
+      // the buggy behavior cause modelB to trigger modelA _delayedTriggers
+      modelA.on("change:name", function(){
+          modelB.set("and.now.for.something.completly", "different");
+      });
+      // assert true (expected behavior)
+      modelA.on("change:name.first", function(){
+          ok(true, "event change:name.first from modelA was triggered on modelA - great!");
+      });
+      // assert false (buggy behavior)
+      modelB.on("change:name.first", function(){
+          ok(false, "event change:name.first from modelA was triggered on modelB - ouch!");
+      });
 
+      modelA.set("name.first", "s");
+    });
 });


### PR DESCRIPTION
See issue #68 for problem details. The fix contains:
- `_delayedTriggers` is wrapped in `_getDelayedTriggers` that creates\returns `this._delayedTriggers`
- `nestedChanges` was replaced by `this._nestedChanged`
- added test accordingly

Credit to https://github.com/ekeren