### PR TITLE
Use safe version of hasOwnProperty.

### DIFF
--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -58,7 +58,7 @@
       } else { // it's an Object
         opts = value || {};
         var attrs = key;
-        for (var _attrStr in attrs) {
+        for (var _attrStr in attrs) { 
           if (Object.hasOwnProperty.call(attrs, _attrStr)) {
             this._setAttr(newAttrs,
                           Backbone.NestedModel.attrPath(_attrStr),
@@ -280,7 +280,7 @@
 
               var nestedAttr, nestedVal;
               for (var a in obj){
-                if (obj.hasOwnProperty(a)) {
+                if (Object.hasOwnProperty.call(obj, a)) {
                   nestedAttr = prefix + '.' + a;
                   nestedVal = obj[a];
                   if (!_.isEqual(model.get(nestedAttr), nestedVal)) {

--- a/backbone-nested.js
+++ b/backbone-nested.js
@@ -59,7 +59,7 @@
         opts = value || {};
         var attrs = key;
         for (var _attrStr in attrs) {
-          if (attrs.hasOwnProperty(_attrStr)) {
+          if (Object.hasOwnProperty.call(attrs, _attrStr)) {
             this._setAttr(newAttrs,
                           Backbone.NestedModel.attrPath(_attrStr),
                           opts.unset ? void 0 : attrs[_attrStr],


### PR DESCRIPTION
The `attributes` property was called with the assumption that a `hasOwnProperty` method existed. This is not the case if using `null` as the top-level parent for the `attributes` property, as some 3rd party Backbone libraries introduced.
